### PR TITLE
Fix chrome audio error using AudioContext

### DIFF
--- a/system_runner.js
+++ b/system_runner.js
@@ -25,7 +25,7 @@ function songLoaded() {
   songButton.elt.disabled = false;
   // let now = millis();
   // songEpoch = now + 5000;
-  if(debugFastRefresh){
+  if(debugFastRefresh && getAudioContext().state != "suspended"){
     switchRunMode()
   }
 }

--- a/system_settings.js
+++ b/system_settings.js
@@ -1,4 +1,4 @@
 // smoothing is applied to the audio file to smooth the signal
 // expected values are from 0 (no smoothing) to 100 (lots of smoothing)
 const smoothing = 25;
-const debugFastRefresh = false;
+const debugFastRefresh = true;


### PR DESCRIPTION
Chrome fails to play on some versions if loading the page, due to requiring user interaction before playing audio. This works on the code save refresh as the webaudio context isn't reloaded.

also default debugFastRefresh as per release.

